### PR TITLE
Accept timeouts when checking links with Lychee

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: "--no-progress --config .lychee.toml --files-from urls.txt"
+          args: "--no-progress --accept-timeouts --config .lychee.toml --files-from urls.txt"
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -17,6 +17,12 @@ max_concurrency = 14
 
 #############################  Requests  ############################
 
+# Website timeout from connect to response finished
+timeout = 20
+
+# Minimum wait time in seconds between retries of failed requests
+retry_wait_time = 5
+
 # Comma-separated list of accepted status codes for valid links.
 accept = ["100..=103", "200..=204", "403", "429"]
 


### PR DESCRIPTION
Prevent issues being opened as a result of webpages timing out.