### PR TITLE
Fix webring pointing to old green color

### DIFF
--- a/src/content/webrings/2-css-joy.yml
+++ b/src/content/webrings/2-css-joy.yml
@@ -3,4 +3,4 @@ description: '"For those of us who take joy in messing around with CSS."'
 url: https://cs.sjoy.lol/
 prev: https://webri.ng/webring/cssjoy/previous?via=https://ky.fyi/webrings
 next: https://webri.ng/webring/cssjoy/next?via=https://ky.fyi/webrings
-color: jade
+color: green


### PR DESCRIPTION
`jade` was replaced with `green` in #867 — fix the webring still using the old color.